### PR TITLE
Prevent "Mounts Denied" error when running `warden env up -d`

### DIFF
--- a/tools/init.sh
+++ b/tools/init.sh
@@ -21,6 +21,7 @@ cd "${BASE_DIR}"
 
 ## load configuration needed for setup
 REQUIRED_FILES=("webroot/auth.json")
+REQUIRED_DIRECTORIES=("webroot/pub/media")
 source .env
 DB_DUMP="${DB_DUMP:-/tmp/magento-db.sql.gz}"
 DB_IMPORT=1
@@ -108,6 +109,11 @@ for REQUIRED_FILE in ${REQUIRED_FILES[@]}; do
     >&2 printf "\e[01;31mERROR\033[0m: Missing local file: ${REQUIRED_FILE} \n"
     INIT_ERROR=1
   fi
+done
+
+## ensure required directories exist
+for REQUIRED_DIRECTORY in ${REQUIRED_DIRECTORIES[@]}; do
+  mkdir -p ${REQUIRED_DIRECTORY}
 done
 
 ## exit script if there are any missing dependencies or configuration files


### PR DESCRIPTION
I was getting this error:

```
./tools/init.sh --clean-install
…
…
Starting m2_php-debug_1 ...
Starting m2_php-fpm_1   ...
docker.errors.APIError: 500 Server Error: Internal Server Error ("b'Mounts denied: \r\nThe path /server/sites/m2.test/webroot/pub/media\r\nis not shared from OS X and is not known to Docker.\r\nYou can configure shared paths from Docker -> Preferences... -> File Sharing.\r\nSee https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.\r\n.'")
```

[Screenshot of the error](https://take.ms/3ATEM)

After making the changes in this PR, the error went away.