### PR TITLE
Adds grunt.sh

### DIFF
--- a/tools/grunt.sh
+++ b/tools/grunt.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -eu
+trap 'error "$(printf "Command \`%s\` on line $LINENO failed with exit code $?" "$BASH_COMMAND")"' ERR
+
+function error {
+  >&2 printf "\033[31mERROR\033[0m: $@\n"
+}
+
+function :: {
+  echo
+  echo "==> [$(date +%H:%M:%S)] $@"
+}
+
+## find directory above where this script is located following symlinks if neccessary
+readonly BASE_DIR="$(
+  cd "$(
+    dirname "$(
+      (readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}") \
+        | sed -e "s#^../#$(dirname "$(dirname "${BASH_SOURCE[0]}")")/#"
+    )"
+  )/.." >/dev/null \
+  && pwd
+)"
+cd "${BASE_DIR}"
+
+## load configuration needed for setup
+source .env
+WARDEN_WEB_ROOT="$(echo "${WARDEN_WEB_ROOT:-/}" | sed 's#^/#./#')"
+REQUIRED_FILES=("${WARDEN_WEB_ROOT}/package.json" "${WARDEN_WEB_ROOT}/Gruntfile.js")
+GRUNT_ERROR=
+WATCH=
+THEME=
+
+while (( "$#" )); do
+    case "$1" in
+        -w|--watch)
+            WATCH=1
+            shift
+            THEME="$1"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $(basename $0) [-w|--watch] <theme>"
+            echo ""
+            echo "       -w|--watch                Watch for file changes"
+            echo ""
+            exit -1
+            ;;
+        *)
+            THEME="$1"
+            shift
+            ;;
+    esac
+done
+
+## check for presence of local configuration files to ensure they exist
+for REQUIRED_FILE in ${REQUIRED_FILES[@]}; do
+  if [[ ! -f "${REQUIRED_FILE}" ]]; then
+    error "Missing local file: ${REQUIRED_FILE}"
+    GRUNT_ERROR=1
+  fi
+done
+
+## exit script if there are any missing dependencies or configuration files
+[[ ${GRUNT_ERROR} ]] && exit 1
+
+:: Installing node dependencies
+warden env exec -T php-fpm npm install
+
+:: Compiling static assets
+if [[ ${THEME} ]];
+then
+    warden env exec -T php-fpm grunt exec:${THEME}
+    warden env exec -T php-fpm grunt less:${THEME}
+else
+    warden env exec -T php-fpm grunt exec
+    warden env exec -T php-fpm grunt less
+fi
+
+if [[ ${WATCH} ]]; then
+    warden env exec -T php-fpm grunt watch
+fi


### PR DESCRIPTION
This PR adds `tools/grunt.sh` which can be used to run Grunt within the `php-fpm` container. The script does the following:

- Checks if the `package.json` and `Gruntfile.js` files exist in the webroot
- Installs node dependencies on each run

## Examples

```bash
# Runs grunt exec and grunt less for all themes that are configured
./tools/grunt.sh
```

```bash
# Runs grunt exec:luma and grunt less:luma
./tools/grunt.sh luma
```

```bash
# You can optionally pass the -w or --watch flags to have grunt watch run.
./tools/grunt.sh --watch luma
```

## Remaining items
There are still a couple of items that need to be resolved:

- [ ] When running `./tools/grunt.sh --watch` a second time I receive the following error
```
Fatal error: Port 35729 is already in use by another process.
```

- [ ] When aborting the `grunt watch` process it exits with exit code 1 and I'm thinking that `docker exec` takes it as an error. I'm not sure where to start to resolve this issue so any input here would be really appreciated @davidalger 😄 
```
^CERROR: Aborting.
ERROR: Command `warden env exec -T php-fpm grunt watch` on line 82 failed with exit code 
```