### PR TITLE
Update for Warden 0.6.0

### DIFF
--- a/.warden/commands/bootstrap.cmd
+++ b/.warden/commands/bootstrap.cmd
@@ -146,7 +146,7 @@ done
 [[ ${INIT_ERROR} ]] && exit 1
 
 :: Starting Warden
-warden up
+warden svc up
 if [[ ! -f ~/.warden/ssl/certs/${TRAEFIK_DOMAIN}.crt.pem ]]; then
     warden sign-certificate ${TRAEFIK_DOMAIN}
 fi

--- a/.warden/commands/bootstrap.help
+++ b/.warden/commands/bootstrap.help
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+WARDEN_USAGE=$(cat <<EOF
+\033[33mUsage:\033[0m
+  bootstrap [--skip-db-import] [--db-dump <file>.sql.gz]
+
+\033[33mOptions:\033[0m
+  -h, --help        Display this help menu
+
+  --clean-install   install from scratch rather than use existing database dump;
+                    implied when no composer.json file is present in web root
+
+  --meta-package    passed to 'composer create-project' when --clean-install is
+                    specified and defaults to 'magento/project-community-edition'
+
+  --meta-version    specify alternate version to install; defaults to latest; may
+                    be (for example) specified as 2.3.x (latest minor) or 2.3.4
+
+  --no-pull         when specified latest images will not be explicitly pulled prior
+                    to environment startup to facilitate use of locally built images
+
+  --skip-db-import  skips over db import (assume db has already been imported)
+
+\033[33mArguments:\033[0m
+
+  --db-dump <file>.sql.gz      expects path to .sql.gz file for import during init
+
+EOF
+)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Other useful URLs on DEV:
 
 ### Prerequisites:
 
-* [Warden](https://warden.dev/) 0.5.2 or later is installed. See the [Installing Warden](https://docs.warden.dev/installing.html) docs page for further info and procedures.
+* [Warden](https://warden.dev/) 0.6.0 or later is installed. See the [Installing Warden](https://docs.warden.dev/installing.html) docs page for further info and procedures.
 * `pv` is installed and available in your `$PATH` (you can install this via `brew`, `dnf`, `apt` etc)
 
 ### Initializing Environment
@@ -50,7 +50,7 @@ In the below examples `~/Sites/exampleproject` is used as the path. Simply repla
 
  4. Run the init script to bootstrap the environment, starting the containers and mutagen sync (on macOS), installing the database (or importing if `--db-dump` is specified), and creating the local admin user for accessing the Magento backend.
 
-        ./tools/init.sh --clean-install
+        warden bootstrap --clean-install
 
  5. Load the site in your browser using the links and credentials taken from the init script output. 
 


### PR DESCRIPTION
**This PR accomplishes the following:**
* Moves `./tools/init.sh` to be executed as a per-project `warden bootstrap` command.
* Updates use of `warden up` to use `warden svc up` cleaning up deprecation warnings.
* Updates Warden requirement to 0.6.0 or greater.

**Help text for `warden bootstrap` as-implemented:**
```
davidalger:05:50 PM:/sites/m2template (warden-0.6.0) $ warden bootstrap -h
Usage:
  bootstrap [--skip-db-import] [--db-dump <file>.sql.gz]

Options:
  -h, --help        Display this help menu

  --clean-install   install from scratch rather than use existing database dump;
                    implied when no composer.json file is present in web root

  --meta-package    passed to 'composer create-project' when --clean-install is
                    specified and defaults to 'magento/project-community-edition'

  --meta-version    specify alternate version to install; defaults to latest; may
                    be (for example) specified as 2.3.x (latest minor) or 2.3.4

  --no-pull         when specified latest images will not be explicitly pulled prior
                    to environment startup to facilitate use of locally built images

  --skip-db-import  skips over db import (assume db has already been imported)

Arguments:

  --db-dump <file>.sql.gz      expects path to .sql.gz file for import during init
```