### PR TITLE
Read environment variables when doing clean install.

### DIFF
--- a/.warden/commands/bootstrap.cmd
+++ b/.warden/commands/bootstrap.cmd
@@ -10,6 +10,7 @@ function :: {
 ## load configuration needed for setup
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
+
 assertDockerRunning
 
 ## change into the project directory
@@ -26,9 +27,6 @@ META_PACKAGE="magento/project-community-edition"
 META_VERSION=""
 URL_FRONT="https://${TRAEFIK_SUBDOMAIN}.${TRAEFIK_DOMAIN}/"
 URL_ADMIN="https://${TRAEFIK_SUBDOMAIN}.${TRAEFIK_DOMAIN}/backend/"
-SERVICE_RABBITMQ=1
-SERVICE_REDIS=1
-SERVICE_VARNISH=1
 
 ## argument parsing
 ## parse arguments
@@ -63,21 +61,6 @@ while (( "$#" )); do
         --db-dump)
             shift
             DB_DUMP="$1"
-            shift
-            ;;
-        --service-rabbitmq)
-            shift
-            SERVICE_RABBITMQ="$1"
-            shift
-            ;;
-        --service-redis)
-            shift            
-            SERVICE_REDIS="$1"
-            shift
-            ;;
-        --service-varnish)
-            shift
-            SERVICE_VARNISH="$1"
             shift
             ;;
         --no-pull)
@@ -202,7 +185,7 @@ elif [[ ${CLEAN_INSTALL} ]]; then
   INSTALL_FLAGS=""
 
   ## rabbitmq
-  if [[ ${SERVICE_RABBITMQ} == 1 ]]; then
+  if [[ ${WARDEN_RABBITMQ} == 1 ]]; then
     INSTALL_FLAGS="${INSTALL_FLAGS} --amqp-host=rabbitmq
       --amqp-port=5672
       --amqp-user=guest 
@@ -211,7 +194,7 @@ elif [[ ${CLEAN_INSTALL} ]]; then
   fi
   
   ## redis
-  if [[ ${SERVICE_REDIS} == 1 ]]; then
+  if [[ ${WARDEN_REDIS} == 1 ]]; then
     INSTALL_FLAGS="${INSTALL_FLAGS} --session-save=redis
       --session-save-redis-host=redis
       --session-save-redis-port=6379
@@ -228,7 +211,7 @@ elif [[ ${CLEAN_INSTALL} ]]; then
   fi
 
   ## varnish
-  if [[ ${SERVICE_VARNISH} == 1 ]]; then
+  if [[ ${WARDEN_VARNISH} == 1 ]]; then
     INSTALL_FLAGS="${INSTALL_FLAGS} --http-cache-hosts=varnish:80 "
   fi
 

--- a/.warden/commands/bootstrap.help
+++ b/.warden/commands/bootstrap.help
@@ -21,12 +21,6 @@ WARDEN_USAGE=$(cat <<EOF
                     to environment startup to facilitate use of locally built images
 
   --skip-db-import  skips over db import (assume db has already been imported)
-  
-  --service-rabbitmq    use RabbitMQ for message queue service. value 0, 1 default is 1
-  
-  --service-redis   use Redis for backend, page and session cache. value 0, 1 default is 1
-  
-  --service-varnish use Varnish service for http cache. value 0, 1 default is 1
 
 \033[33mArguments:\033[0m
 

--- a/.warden/commands/bootstrap.help
+++ b/.warden/commands/bootstrap.help
@@ -21,6 +21,12 @@ WARDEN_USAGE=$(cat <<EOF
                     to environment startup to facilitate use of locally built images
 
   --skip-db-import  skips over db import (assume db has already been imported)
+  
+  --service-rabbitmq    use RabbitMQ for message queue service. value 0, 1 default is 1
+  
+  --service-redis   use Redis for backend, page and session cache. value 0, 1 default is 1
+  
+  --service-varnish use Varnish service for http cache. value 0, 1 default is 1
 
 \033[33mArguments:\033[0m
 


### PR DESCRIPTION
This PR reads the existing environment variables (WARDEN_RABBITMQ, WARDEN_REDIS, WARDEN_VARNISH) and will alter the list of Magento installation flags during a clean install to align w/the configured environment.

Please let me know if you see this as useful or have comments / concerns on implementation, etc.