### PR TITLE
Remove existing app config on clean install

### DIFF
--- a/.warden/commands/bootstrap.cmd
+++ b/.warden/commands/bootstrap.cmd
@@ -181,7 +181,7 @@ if [[ ${DB_IMPORT} ]]; then
   pv "${DB_DUMP}" | gunzip -c | warden db import
 elif [[ ${CLEAN_INSTALL} ]]; then
   :: Installing application
-  warden env exec -- -T php-fpm rm -vf app/etc/config.php app/etc/env.php
+  warden env exec -- -T php-fpm rm -vf app/etc/config.php app/etc/env.php app/etc/env.php.warden.php
   warden env exec -- -T php-fpm cp app/etc/env.php.init.php app/etc/env.php
   warden env exec -- -T php-fpm bin/magento setup:install \
       --cleanup-database \


### PR DESCRIPTION
Clean install should reflect environment variable values when installing Magento, this PR removes app/etc/env.php.warden.php to pickup environment changes which may have occurred.