### PR TITLE
Feature/gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ node_modules
 !/webroot/app/design
 /webroot/app/design/adminhtml/Magento
 /webroot/app/design/frontend/Magento
-/webroot/app/etc/*
 !/webroot/app/etc/config.php
 !/webroot/app/etc/env.php.warden.php
 !/webroot/app/etc/env.php.init.php

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,10 @@
 node_modules
 
 /webroot/*
-!/webroot/app
-/webroot/app/*
-!/webroot/app/etc
+!/webroot/app/code
+!/webroot/app/design
+/webroot/app/design/adminhtml/Magento
+/webroot/app/design/frontend/Magento
 /webroot/app/etc/*
 !/webroot/app/etc/config.php
 !/webroot/app/etc/env.php.warden.php


### PR DESCRIPTION
This PR allows for modules to be added to the psr-0 autoload path webroot/app/code. 
Also allow themes to be installed locally at app/design/namespace (ignore app/design/{adminhtml,frontend}/Magento).
Cleanup overrides of app and app/etc.

This helps for project based usage of the .gitignore. LMK if this does not make sense.